### PR TITLE
Fix composer installation script path

### DIFF
--- a/ansible/roles/composer/tasks/main.yml
+++ b/ansible/roles/composer/tasks/main.yml
@@ -4,9 +4,9 @@
     path: /usr/local/bin/composer
   register: composer_stat
 - name: Download Composer
-  script: scripts/install-composer.sh
+  script: "{{ playbook_dir }}/scripts/install-composer.sh"
   when: not composer_stat.stat.exists
-- name: Move composer globaly
+- name: Move composer globally
   become: true
   command: "mv composer.phar /usr/local/bin/composer"
   when: not composer_stat.stat.exists


### PR DESCRIPTION
## Summary
- fix composer role to reference correct install script path
- correct typo in composer role task name

## Testing
- `pip install -r requirements.txt` *(fails: Building wheel for pycrypto did not run successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6894f057f5b0833292fceb179756c28f